### PR TITLE
chore: improve OpenSSF Scorecard compliance

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -15,6 +15,11 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
       - name: Dependabot metadata
         id: metadata
         if: github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
   schedule:
     - cron: '0 6 * * 1'
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,28 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always

--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -15,6 +15,11 @@ jobs:
       TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,41 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '25 6 * * 1'
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
+        with:
+          sarif_file: results.sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+Use [GitHub Security Advisories](https://github.com/netresearch/t3x-nr_perfanalysis/security/advisories/new) to report vulnerabilities privately.
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce (proof of concept if possible)
+- Affected versions
+- Potential impact assessment
+- Suggested fix (if any)
+
+### Response Timeline
+
+| Severity | Initial Response | Fix Target   |
+|----------|------------------|--------------|
+| Critical | 48 hours         | 7 days       |
+| High     | 5 business days  | 30 days      |
+| Medium   | 10 business days | 90 days      |
+| Low      | 14 business days | Next release |
+
+### What to Expect
+
+1. **Acknowledgment**: We will acknowledge receipt of your report within the timelines above
+2. **Assessment**: We will investigate and assess the severity of the vulnerability
+3. **Fix**: We will develop and test a fix
+4. **Disclosure**: We will coordinate disclosure with you and publish a security advisory
+
+### Scope
+
+This policy covers the `nr_perfanalysis` TYPO3 extension code. For vulnerabilities in dependencies or TYPO3 core, please report to the respective upstream projects.
+
+## Safe Harbor
+
+We consider security research conducted in good faith to be authorized. We will not pursue legal action against researchers who follow responsible disclosure practices.


### PR DESCRIPTION
## Summary
- Add OpenSSF Scorecard workflow for supply chain security monitoring
- Add dependency review for PR dependency scanning
- Add SECURITY.md with vulnerability reporting process
- Add `step-security/harden-runner` to all workflow jobs
- Fix `codeql.yml` branch triggers from `main` to `master` (matching the actual default branch)

## Impact
Enables OpenSSF Scorecard scoring and addresses Token-Permissions, Pinned-Dependencies, Security-Policy, and SAST checks.

## Test plan
- [ ] All existing CI workflows still pass
- [ ] Scorecard workflow runs successfully
- [ ] Dependency review triggers on PRs