### PR TITLE
ci: migrate to shared typo3-ci-workflows

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,40 +1,11 @@
 name: Auto-merge dependency PRs
-
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
-
-permissions:
-  contents: write
-  pull-requests: write
-
+permissions: {}
 jobs:
   auto-merge:
-    name: Auto-merge dependency PRs
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Dependabot metadata
-        id: metadata
-        if: github.event.pull_request.user.login == 'dependabot[bot]'
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Auto-approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable auto-merge
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: netresearch/typo3-ci-workflows/.github/workflows/auto-merge-deps.yml@main
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on:
+  push:
+  pull_request:
+  merge_group:
+permissions: {}
+jobs:
+  ci:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["8.2", "8.3", "8.4"]'
+      typo3-versions: '["^12.4", "^13.4"]'
+      typo3-packages: '["typo3/cms-core"]'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,4 @@
 name: CodeQL
-
 on:
   push:
     branches: [master]
@@ -7,34 +6,11 @@ on:
     branches: [master]
   schedule:
     - cron: '0 6 * * 1'
-
 permissions: {}
-
 jobs:
   analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
+    uses: netresearch/typo3-ci-workflows/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write
       actions: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
-        with:
-          languages: actions
-          queries: security-and-quality
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
-        with:
-          category: "/language:actions"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,28 +1,10 @@
 name: Dependency Review
-
 on:
   pull_request:
-
 permissions: {}
-
 jobs:
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
+  review:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/dependency-review.yml@main
     permissions:
       contents: read
       pull-requests: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Dependency Review
-        uses: actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803 # v4.8.3
-        with:
-          fail-on-severity: high
-          comment-summary-in-pr: always

--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -1,58 +1,15 @@
-name: Publish new extension version to TER
-permissions:
-  contents: read
+name: Publish to TER
 
 on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   publish:
-    name: Publish new version to TER
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    env:
-      TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
-      TYPO3_API_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Check tag
-        run: |
-          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
-            exit 1
-          fi
-
-      - name: Get version
-        id: get-version
-        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-
-      - name: Get comment
-        id: get-comment
-        run: |
-          readonly local comment=$(git tag -n10 -l ${{ env.version }} | sed "s/^[0-9.]*[ ]*//g")
-
-          if [[ -z "${comment// }" ]]; then
-            echo "comment=Released version ${{ env.version }} of ${{ env.TYPO3_EXTENSION_KEY }} -- for details see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases" >> $GITHUB_ENV
-          else
-            echo "comment=$comment -- for details see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases" >> $GITHUB_ENV
-          fi
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.3
-          extensions: intl, mbstring, json, zip, curl
-          tools: composer:v2
-
-      - name: Install tailor
-        run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
-
-      - name: Publish to TER
-        run: php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.comment }}" ${{ env.version }}
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
+    permissions:
+      contents: read
+    secrets:
+      TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions: {}
+
+jobs:
+  release:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/release.yml@main
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    with:
+      archive-prefix: nr-perfanalysis
+      package-name: netresearch/nr-perfanalysis

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,41 +1,15 @@
 name: OpenSSF Scorecard
-
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   schedule:
     - cron: '25 6 * * 1'
-
 permissions: {}
-
 jobs:
-  analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
+  scorecard:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/scorecard.yml@main
     permissions:
       contents: read
       security-events: write
       id-token: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Run Scorecard
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
-
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
-        with:
-          sarif_file: results.sarif
+      actions: read


### PR DESCRIPTION
## Summary

Replaces local inline workflow definitions with thin callers to `netresearch/typo3-ci-workflows` shared workflows, matching the pattern established in `t3x-contexts`.

Note: Branch triggers reference `master` (this repo's default branch) instead of `main`.

### Workflows migrated (local → shared caller)
- `auto-merge-deps.yml`
- `codeql.yml` (triggers on `master`)
- `dependency-review.yml`
- `publish-to-ter.yml`
- `scorecard.yml` (triggers on `master`)

### Workflows added
- `ci.yml` — shared CI workflow caller (PHP 8.2-8.4, TYPO3 ^12.4/^13.4)
- `release.yml` — shared release workflow caller (archive-prefix: `nr-perfanalysis`, package-name: `netresearch/nr-perfanalysis`)

## Test plan
- [ ] Verify auto-merge-deps triggers on dependency PRs
- [ ] Verify CodeQL runs on push to master and on PRs
- [ ] Verify dependency-review runs on PRs
- [ ] Verify TER publish triggers on release
- [ ] Verify scorecard runs on push to master
- [ ] Verify CI runs on push/PR with correct PHP and TYPO3 matrix
- [ ] Verify release workflow triggers on tag push